### PR TITLE
[OPS-958] Add haskell-nix-weeder input for the haskell.nix CI template

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -170,6 +170,17 @@
         "repo": "flake-compat",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "haskell-nix-weeder",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "serokell",
+        "repo": "haskell-nix-weeder",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
Used in https://github.com/serokell/templates/pull/2