### PR TITLE
Repin Nix

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -185,11 +185,11 @@
         "type": "indirect"
       },
       "to": {
-        "lastModified": 1652280837,
-        "narHash": "sha256-N4To3tjnks/20pze4r1Wiu7s9+o21RxzKRfVX6+CDNo=",
+        "lastModified": 1654239108,
+        "narHash": "sha256-0JzuElxLe5DxM+R4tvBYfvQnMGCERZy4KMRf0JYxxS4=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "b944b588fa280b0555b8269c0f6d097352f8716f",
+        "rev": "1dd7253133c4dfd2e7a16ad6fe505442cef38a5b",
         "type": "github"
       }
     }


### PR DESCRIPTION
The current pin of Nix breaks when downloading anything from GitHub, which ruins a lot of things