### PR TITLE
Bump haskell-nix

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -185,11 +185,11 @@
         "type": "indirect"
       },
       "to": {
-        "lastModified": 1667438430,
-        "narHash": "sha256-POHnQtfBdDJP2AHcmTnCC1qMhq81Plq7fuh2xhLCBs8=",
+        "lastModified": 1671151873,
+        "narHash": "sha256-9nisAyp2nusKqvtvps4Uc+I/HPcpbgXkH5qnfqAjsio=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3a7f069ccc491c783a28429aa8bcb504f70dc62b",
+        "rev": "2860f6c26b6c2672b4ed34216efd26a2eb96dd4e",
         "type": "github"
       }
     }


### PR DESCRIPTION
Problem: After an attempt to update nixpkgs in some of our projects, flakes fail with 'error: librevisa has been removed'.

Solution: This issue supposed to be fixed in
https://github.com/input-output-hk/haskell.nix/commit/e601c9ce609af07a78edf1c57f5985931788aeb2 so an update should help.