### PR TITLE
[Chore] Bump haskell.nix

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -185,11 +185,11 @@
         "type": "indirect"
       },
       "to": {
-        "lastModified": 1678950661,
-        "narHash": "sha256-lvL54W90BTvwLVnFjPYmFVmgHyaGcFrt5FBy1F0rro8=",
+        "lastModified": 1688604725,
+        "narHash": "sha256-neLr648fNNlmTqg2pTTQJrf6cOpZGi2OmR2E9dhy/Ts=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "fce554bc6a41d12f7a18a0e8290bf43f925d7a29",
+        "rev": "4464ab9616d214c3b212beac409e93f5d521e561",
         "type": "github"
       }
     }


### PR DESCRIPTION
Problem: One of our projects requires ghc945 which is not in current haskell.nix lock.

Solution: Bump haskell.nix.