### PR TITLE
[Chore] Bump haskell.nix

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -185,11 +185,11 @@
         "type": "indirect"
       },
       "to": {
-        "lastModified": 1695689411,
-        "narHash": "sha256-t2q1IyuigbRpDLsAPzquhsSI5O71c4k3RyzI/c/WZJY=",
+        "lastModified": 1704847818,
+        "narHash": "sha256-LQzIY21CkCirSSR+7fB5uQjlFGBzCvjA0x/TuPXT3V8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "8e42ccd7ed75cd8eeb4cfb47e8ac8dae549e96ae",
+        "rev": "28fceff2ef63b5bd0717371df5500a58ace98ee6",
         "type": "github"
       }
     }


### PR DESCRIPTION
Problem: We want to use GHC-9.8 in one of our projects CI. However currently pinned version of haskell.nix doesn't support this GHC version.

Solution: Bump haskell.nix pinned revision.