### PR TITLE
[OPS-1559] Remove `common-infra`

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -46,17 +46,6 @@
     },
     {
       "from": {
-        "id": "common-infra",
-        "type": "indirect"
-      },
-      "to": {
-        "owner": "serokell",
-        "repo": "common-infra",
-        "type": "github"
-      }
-    },
-    {
-      "from": {
         "id": "vault-secrets",
         "type": "indirect"
       },


### PR DESCRIPTION
Problem: We no longer use common-infra and want to archive it, so we need to remove it from the registry.

Solution: Remove common-infra from the registry.